### PR TITLE
Atualizar entidades integrantes no Intercomp

### DIFF
--- a/principal/disposicoes-fundamentais.tex
+++ b/principal/disposicoes-fundamentais.tex
@@ -57,26 +57,6 @@
 			\item Pós-Graduação em Matemática
 		\end{itemize}
 
-		\item[UNESP - Rio Claro] (representada pela Associação Atlética Acadêmica Tatu Bola), com alunos dos cursos:
-		\begin{itemize}[noitemsep]
-			\item Bacharelado em Ciência da Computação
-			\item Bacharelado em Matemática
-			\item Licenciatura em Matemática
-		\end{itemize}
-
-		\item[UNICAMP - Limeira] (representada pela AAATU, Associação Atlética Acadêmica de Tecnologia da Unicamp), com alunos dos cursos:
-		\begin{itemize}[noitemsep]
-			\item Bacharelado em Sistemas de Informação
-			\item *Engenharia Ambiental (curso não estatutário)
-			\item *Engenharia de Telecomunicação (curso não estatutário)
-			\item Tecnologia em Análise e Desenvolvimento de Sistemas
-			\item *Tecnologia em Saneamento Ambiental (curso não estatutário)
-			\item *Tecnologia em Controle Ambiental (curso não estatutário)
-			\item *Tecnologia em Construção Civil (curso não estatutário)
-			\item *Tecnologia em Construção de Edifícios (curso não estatutário)
-			\item *Pós-Graduação em Tecnologia (curso não estatutário)
-		\end{itemize}
-
 		\item[USP Leste - EACH] (representada pelo DASI, Diretório Acadêmico de Sistemas de Informação), com alunos dos cursos:
 		\begin{itemize}[noitemsep]
 			\item Bacharelado em Sistemas de Informação
@@ -134,43 +114,6 @@
 			\item *Pós-Graduação em Química (curso não estatutário)
 		\end{itemize}
 
-		\item[UFU] (representada pela Liga Compes Computação Matemática Exatas e Estatística UFU), com alunos dos cursos:
-		\begin{itemize}[noitemsep]
-			\item Bacharelado em Análise de Sistemas
-			\item Bacharelado em Estatística
-			\item Bacharelado em Gestão da Informação
-			\item Bacharelado em Sistemas de Informação
-			\item Bacharelado em Matemática
-			\item Pós-Graduação em Ciência da Computação
-			\item Pós-Graduação em Matemática
-			\item *Licenciatura em Química (curso não estatutário)
-			\item *Licenciatura em Física (curso não estatutário)
-		\end{itemize}
-
-		\item[UTFPR] (representada pela Associação Atlética Atlética VII de Maio, Atlética Javas UTFPR), com alunos dos cursos:
-		\begin{itemize}[noitemsep]
-			\item Bacharelado em Ciência da Computação
-			\item *Ciências Biológicas (curso não estatutário)
-			\item Ciência Da Computação
-			\item *Ciências Naturais (curso não estatutário)
-			\item Mestrado Em Ciência da Computação
-			\item *Licenciatura Interdisciplinar em Ciências Naturais (curso não estatutário)
-			\item *Tecnologia Em Alimentos (curso não estatutário)
-			\item Tecnologia em Análise e Desenvolvimento de Sistemas
-			\item *Tecnologia Em Automação Industrial (curso não estatutário)
-			\item *Tecnologia Em Fabricação Mecânica (curso não estatutário)
-		\end{itemize}
-
-		\item[Universidade Presbiteriana Mackenzie] (representada pela Atlética Tecnologia Mackenzie), com alunos dos cursos:
-		\begin{itemize}[noitemsep]
-			\item Tecnólogo em Análise e Desenvolvimento de Sistemas
-			\item Bacharelado em Ciência da Computação
-			\item Bacharelado em Matemática
-			\item Bacharelado em Sistemas de Informação
-			\item Licenciatura em Matémática
-			\item Pós-Graduação em Gestão de Tecnologia
-		\end{itemize}
-
 		\item[USJT - AAATIUSJT] (Associação Atletica Académica de Tecnologia da Informação USJT), com
 		alunos dos cursos:
 		\begin{itemize}[noitemsep]
@@ -197,23 +140,16 @@
 	\begin{xparagraph}
 		São consideradas \textbf{participantes} da \textbf{INTERCOMP} as entidades:
 		\begin{itemize}[noitemsep,leftmargin=2\parindent]
-			\item UNESP – Rio Claro
-			\item UNICAMP - Limeira
 			\item USP Leste - EACH
 			\item UEM
 			\item Faculdade de Tecnologia - Carapicuíba
 			\item UFJF
-			\item UFU
-			\item UTFPR
-			\item Universidade Presbiteriana Mackenzie
+			\item USJT
 		\end{itemize}
 	\end{xparagraph}
 
 	\begin{xparagraph}
-		São consideradas \textbf{convidadas} da \textbf{INTERCOMP} as entidades:
-		\begin{itemize}[noitemsep,leftmargin=2\parindent]
-			\item USJT
-		\end{itemize}
+		Esta edição não contará com a presença de entidades \textbf{convidadas} da \textbf{INTERCOMP}.
 	\end{xparagraph}
 
 	\begin{xparagraph}


### PR DESCRIPTION
- Remove **UNESP - Rio Claro**, **Unicamp - Limeira**, **UFU**, **UTFPR** e **Universidade Prestiteriana Mackenzie** da lista de faculdades participantes do Intercomp.
- Promove a **USJT** de entidade convidada para entidade participante, conforme parágrafo 7° do artigo 3°.