### PR TITLE
Corrigir referência a artigo incorreto

### DIFF
--- a/principal/competicoes.tex
+++ b/principal/competicoes.tex
@@ -9,6 +9,7 @@
 \end{article}
 
 \begin{article}
+	\label{art:jogos.interromp}
 	Se a disputa de uma modalidade for interrompida por distúrbios provocados pela torcida, à disputa deverá continuar com portões fechados, após a retirada da torcida.
 
 	\begin{xparagraph}
@@ -33,6 +34,5 @@
 \end{article}
 
 \begin{article}
-	\label{art:jogos.horario}
 	Quaisquer jogos ou competições que venham a ser realizados terão os horários marcados no período de disputa da competição em questão.
 \end{article}

--- a/principal/modalidades-esportivas.tex
+++ b/principal/modalidades-esportivas.tex
@@ -39,7 +39,7 @@
 \end{article}
 
 \begin{article}
-	As inscrições dos atletas poderão ser feitas com o jogo já iniciado, em todos os esportes, com exceção do Xadrez, Tênis de Mesa, Tênis e de partidas interrompidas, conforme art. \ref{art:jogos.horario}o, sendo este artigo soberano às regras das federações.
+	As inscrições dos atletas poderão ser feitas com o jogo já iniciado, em todos os esportes, com exceção do Xadrez, Tênis de Mesa, Tênis e de partidas interrompidas, conforme art. \ref{art:jogos.interromp}o, sendo este artigo soberano às regras das federações.
 \end{article}
 
 \begin{article}


### PR DESCRIPTION
O artigo 15° do estatuto de 2018 diz:

> As inscrições dos atletas poderão ser feitas com o jogo já iniciado, em todos os esportes, com exceção do Xadrez, Tênis de Mesa, Tênis e de partidas interrompidas, conforme art. 35°, sendo este artigo soberano às regras das federações.

No entanto, a referência ao artigo 35° está desatualizada e na verdade deveria apontar para o artigo 34°. Observando-se os estatutos de [2008](https://github.com/rmobis/estatuto-intercomp/files/2775026/estatuto-2008.pdf) e [2010](https://github.com/rmobis/estatuto-intercomp/files/2775025/estatuto-2010.pdf) (recuperados milagrosamente pelo Google Drive) pode-se perceber que o problema foi causado pela inserção do artigo 8° no estatuto de 2010 sem ser feita atualização da referência.

Sendo assim, essa PR altera a referência para o artigo correto (34°) através das referências do LaTeX.

