### PR TITLE
Permitir a participação de delegações não esportivas

### DIFF
--- a/principal/comissao-organizadora.tex
+++ b/principal/comissao-organizadora.tex
@@ -192,7 +192,7 @@
 	\end{xparagraph}
 
 	\begin{xparagraph}
-		A Comissão Organizadora Executiva deverá fixar um valor a ser cobrado de cada atlética participante para a viabilização da \textbf{INTERCOMP}.
+		A Comissão Organizadora Executiva deverá fixar um valor a ser cobrado de cada atlética participante para a viabilização da \textbf{INTERCOMP}. O valor por pacote deve ser o mesmo para todas as delegações.
 	\end{xparagraph}
 
 	\begin{xparagraph}

--- a/principal/modalidades-esportivas.tex
+++ b/principal/modalidades-esportivas.tex
@@ -35,7 +35,7 @@
 \end{article}
 
 \begin{article}
-	A participação de uma faculdade em cada modalidade é opcional. As participantes deverão inscrever-se nas modalidades em disputa até um prazo máximo a ser definido pela C.O. Cada participante deverá se inscrever em um mínimo de 30\% das modalidades da \textbf{INTERCOMP} sendo disputada, e, caso falhe em se inscrever neste número mínimo de modalidades, será desclassificada da competição.
+	A participação de uma faculdade em cada modalidade é opcional. As participantes deverão inscrever-se nas modalidades em disputa até um prazo máximo a ser definido pela C.O. Cada participante poderá se inscrever em quantas modalidades desejar, não havendo um mínimo nem máximo.
 \end{article}
 
 \begin{article}


### PR DESCRIPTION
Essa PR altera o artigo 14°, do capítulo _Modalidades Esportivas_, que antes lia:

> A participação de uma faculdade em cada modalidade é opcional. As participantes deverão inscrever-se nas modalidades em disputa até um prazo máximo a ser definido pela C.O. Cada participante poderá se inscrever em quantas modalidades desejar, não havendo um mínimo nem máximo. de 30% das modalidades da **INTERCOMP** sendo disputada, e, caso falhe em se inscrever neste número mínimo de modalidades, será desclassificada da competição.

Agora, com a alteração da útima frase para remover o requerimento mínimo de 30%, lê-se _(ênfase minha)_:

> A participação de uma faculdade em cada modalidade é opcional. As participantes deverão inscrever-se nas modalidades em disputa até um prazo máximo a ser definido pela C.O. Cada participante **poderá se inscrever em quantas modalidades desejar, não havendo um mínimo nem máximo**.

