### PR TITLE
Corrige referência ao misterioso artigo X

### DIFF
--- a/principal/forma-de-disputa.tex
+++ b/principal/forma-de-disputa.tex
@@ -1,10 +1,14 @@
 {\let\clearpage\relax \chapter{Forma de Disputa}}
 
-\noindent
-Ficam definidos como cabeças de chave de cada modalidade as 4 (quatro) equipes melhor classificadas naquela modalidade na edição última do Intercomp
-\begin{itemize}[noitemsep]
-	\item Caso a modalidade não tenha sido disputada na última edição do Intercomp, considerar-se-ão as classificações gerais da última edição do Intercomp
-\end{itemize}
+\begin{article}
+	\label{art:cabecas}
+	Ficam definidos como cabeças de chave de cada modalidade as 4 (quatro) equipes melhor classificadas naquela modalidade na edição última do Intercomp
+
+	\begin{xparagraph}
+		Caso a modalidade não tenha sido disputada na última edição do Intercomp, considerar-se-ão as classificações gerais da última edição do Intercomp
+	\end{xparagraph}
+\end{article}
+
 
 \noindent
 Fica definido como \textit{Disputa em Eliminatórias Simples} o seguinte sistema de diputa::
@@ -94,8 +98,8 @@ Será realizado sorteio para alocação das participantes que não são cabeças
 \begin{itemize}[noitemsep]
 	\item Havendo grupo único, não será realizado sorteio
 	\item Havendo 2 (dois) grupos, as participantes a serem sorteadas são colocadas em um \textit{Pote Único}, do qual serão sortedas para ocupar as posições restantes em cada grupo
-	\item Havendo 3 (três) grupos, as duas participantes a serem sorteadas mais bem classificadas de acordo com as regras para definição de cabeças de chave do artigo X serão colocadas no \textit{Pote 1}, do qual serão sorteadas uma para o grupo A e a outra para o grupo B. As demais participantes a serem sorteadas serão colocadas no \textit{Pote 2}, do qual serão sorteadas para ocupar as posições restantes em cada grupo.
-	\item Havendo 4 (quatro) grupos, as quatro participantes a serem sorteadas mais bem classificadas de acordo com as regras para definição de cabeças de chave do artigo X serão colocadas no \textit{Pote 1}, do qual serão sorteadas cada uma para um grupo. As demais participantes a serem sorteadas serão colocadas no \textit{Pote 2}, do qual serão sorteadas para ocupar as posições restantes em cada grupo.
+	\item Havendo 3 (três) grupos, as duas participantes a serem sorteadas mais bem classificadas de acordo com as regras para definição de cabeças de chave do art. \ref{art:cabecas}° serão colocadas no \textit{Pote 1}, do qual serão sorteadas uma para o grupo A e a outra para o grupo B. As demais participantes a serem sorteadas serão colocadas no \textit{Pote 2}, do qual serão sorteadas para ocupar as posições restantes em cada grupo.
+	\item Havendo 4 (quatro) grupos, as quatro participantes a serem sorteadas mais bem classificadas de acordo com as regras para definição de cabeças de chave do art. \ref{art:cabecas}° serão colocadas no \textit{Pote 1}, do qual serão sorteadas cada uma para um grupo. As demais participantes a serem sorteadas serão colocadas no \textit{Pote 2}, do qual serão sorteadas para ocupar as posições restantes em cada grupo.
 \end{itemize}
 
 \noindent


### PR DESCRIPTION
Conversão do primeiro parágrafo de texto do capítulo _Forma de Disputa_, adaptando-o a um artigo para que possamos referencia-lo mais para baixo, no parágrafo que trata sobre o sorteio das participantes, substituindo a referência ao "artigo X".

**Trecho antes da alteração** _(enfâse minha)_
> ... as regras para definição de cabeças de chave do **artigo X** serão colocadas no _Pote 1_, do qual ...


**Trecho após a alteração** _(enfâse minha)_
> ... as regras para definição de cabeças de chave do **art. 12°** serão colocadas no _Pote 1_, do qual ...

Investigando o histórico dos estatutos, descobri que esse trecho foi introduzido numa versão do estatuto entre [2016](https://github.com/rmobis/estatuto-intercomp/files/2775080/estatuto-2016.pdf) e [2018](https://github.com/rmobis/estatuto-intercomp/files/2775081/estatuto-2018.pdf) e nunca fez referência a nenhnum artigo, provavelmente pois a formatação do capítulo inteiro está problemática. De qualquer maneira, acredito que observando-se o contexto fica óbvio que a referência é de fato ao artigo referido aqui.

**PS:** O capítulo inteiro precisaria ser reformatado na verdade, mas como não sei se vou ter tempo de fazer isso deixei essa PR inicial por enquanto.